### PR TITLE
strings containig special characters produce invalid signature

### DIFF
--- a/src/main/java/com/fireblocks/sdk/Fireblocks.java
+++ b/src/main/java/com/fireblocks/sdk/Fireblocks.java
@@ -16,6 +16,7 @@ package com.fireblocks.sdk;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fireblocks.sdk.api.*;
+
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
@@ -93,8 +94,8 @@ public class Fireblocks {
             try {
                 signingAlgorithm = Algorithm.RSA256(null, getPrivateKey(secretKey));
             } catch (NoSuchAlgorithmException
-                    | InvalidKeySpecException
-                    | IllegalArgumentException e) {
+                     | InvalidKeySpecException
+                     | IllegalArgumentException e) {
                 e.printStackTrace();
                 throw new IllegalArgumentException("Invalid secretKey");
             }
@@ -155,10 +156,7 @@ public class Fireblocks {
     private String signJwt(HttpRequest.Builder builder) throws NoSuchAlgorithmException {
         HttpRequest request = builder.build();
         String path =
-                request.uri().getPath()
-                        + Optional.ofNullable(request.uri().getQuery())
-                                .map(query -> "?" + query)
-                                .orElse("");
+                request.uri().toString().substring(request.uri().getHost().length() + 8);
 
         byte[] bytes =
                 request.bodyPublisher()


### PR DESCRIPTION
fixing bug when vaultPrefix,suffix is signed before url encode and characters ":%#@" etc produce invalid signature

## Pull Request Description

to get path I use to string and strip host instead of concatenating path and query 

Fixes [(link to the issue here)](https://github.com/fireblocks/java-sdk/issues/14)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code

