### PR TITLE
[OC-7791] Tokenization - Updated deserialization for stricter parsing

### DIFF
--- a/src/main/java/com/fireblocks/sdk/model/TokenLinkDtoTokenMetadata.java
+++ b/src/main/java/com/fireblocks/sdk/model/TokenLinkDtoTokenMetadata.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fireblocks.sdk.JSON;
 import java.io.IOException;
 import java.util.Collections;
@@ -78,6 +79,8 @@ public class TokenLinkDtoTokenMetadata extends AbstractOpenApiSchema {
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
+            ObjectMapper objectMapper = new ObjectMapper();
+
             // deserialize AssetMetadataDto
             try {
                 boolean attemptParsing = true;
@@ -108,10 +111,7 @@ public class TokenLinkDtoTokenMetadata extends AbstractOpenApiSchema {
                     }
                 }
                 if (attemptParsing) {
-                    deserialized = tree.traverse(jp.getCodec()).readValueAs(AssetMetadataDto.class);
-                    // TODO: there is no validation against JSON schema constraints
-                    // (min, max, enum, pattern...), this does not perform a strict JSON
-                    // validation, which means the 'match' count may be higher than it should be.
+                    deserialized = objectMapper.readValue(tree.traverse(jp.getCodec()), AssetMetadataDto.class);
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AssetMetadataDto'");
                 }
@@ -150,11 +150,7 @@ public class TokenLinkDtoTokenMetadata extends AbstractOpenApiSchema {
                     }
                 }
                 if (attemptParsing) {
-                    deserialized =
-                            tree.traverse(jp.getCodec()).readValueAs(CollectionMetadataDto.class);
-                    // TODO: there is no validation against JSON schema constraints
-                    // (min, max, enum, pattern...), this does not perform a strict JSON
-                    // validation, which means the 'match' count may be higher than it should be.
+                    deserialized = objectMapper.readValue(tree.traverse(jp.getCodec()), CollectionMetadataDto.class);
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CollectionMetadataDto'");
                 }
@@ -193,11 +189,7 @@ public class TokenLinkDtoTokenMetadata extends AbstractOpenApiSchema {
                     }
                 }
                 if (attemptParsing) {
-                    deserialized =
-                            tree.traverse(jp.getCodec()).readValueAs(ContractMetadataDto.class);
-                    // TODO: there is no validation against JSON schema constraints
-                    // (min, max, enum, pattern...), this does not perform a strict JSON
-                    // validation, which means the 'match' count may be higher than it should be.
+                    deserialized = objectMapper.readValue(tree.traverse(jp.getCodec()), ContractMetadataDto.class);
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'ContractMetadataDto'");
                 }


### PR DESCRIPTION
## Pull Request Description

Deserializer for TokenLinkDtoTokenMetadata is not strict enough and pick up all 3 subtypes: AssetMetadataDto, CollectionMetadataDto and ContractMetadataDto and throws an exception even though for example the json is for AssetMetadataDto and has only properties that belong to AssetMetadataDto 

Example SDK call `TokenLinkDto data = fireblocks.tokenization().getLinkedToken(idToken).join().getData();`

Exception thrown
> java.util.concurrent.CompletionException: com.fireblocks.sdk.ApiException: com.fasterxml.jackson.databind.JsonMappingException: Unexpected IOException (of type java.io.IOException): Failed deserialization for TokenLinkDtoTokenMetadata: 3 classes match result, expected 1

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Locally tested against Fireblocks API

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
